### PR TITLE
[FEAT] Access 토큰 재발급 및 로그인 검사 구간 리팩토링

### DIFF
--- a/src/apis/authAxois.ts
+++ b/src/apis/authAxois.ts
@@ -30,7 +30,7 @@ export const AuthVerify = () => {
 };
 
 // 주어진 토큰을 사용하여 API 요청에 인증된 Axios 인스턴스를 초기화
-export const getAuthAxios = (token: string) => {
+export const getAuthAxios = (token: string | null) => {
 	// Axios 인스턴스 생성
 	const authAxios = axios.create({
 		baseURL,

--- a/src/apis/authAxois.ts
+++ b/src/apis/authAxois.ts
@@ -1,0 +1,75 @@
+import axios from 'axios';
+import { getNewToken } from './login';
+import LocalStorage from '@/utils/localStorage';
+
+const baseURL = process.env.NEXT_PUBLIC_SERVER_URL;
+
+const parseJwt = (token: string | null) => {
+	if (token) return JSON.parse(atob(token.split('.')[1]));
+};
+// 토큰 유효성 검사
+export const AuthVerify = () => {
+	const access = LocalStorage.getItem('access');
+	const refresh = LocalStorage.getItem('refresh');
+
+	if (!access || !refresh) {
+		return '필요 토큰 미존재';
+	}
+
+	const decodedAccess = parseJwt(access);
+	const decodedRefresh = parseJwt(refresh);
+
+	if (decodedAccess && decodedAccess.exp * 1000 < Date.now()) {
+		return 'Access 토큰 만료';
+	}
+	if (decodedRefresh && decodedRefresh.exp * 1000 < Date.now()) {
+		return 'Refresh 토큰 만료';
+	}
+
+	return decodedAccess ? true : false;
+};
+
+// 주어진 토큰을 사용하여 API 요청에 인증된 Axios 인스턴스를 초기화
+export const getAuthAxios = (token: string) => {
+	// Axios 인스턴스 생성
+	const authAxios = axios.create({
+		baseURL,
+		timeout: 8000,
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
+	});
+
+	// 응답 인터셉터 설정
+	authAxios.interceptors.response.use(
+		(response) => {
+			return response;
+		},
+		async (error) => {
+			const originalRequest = error.config;
+
+			try {
+				// 토큰 갱신 시도
+				const { accessToken } = await getNewToken();
+
+				if (!accessToken) {
+					throw new Error('토큰 갱신 실패');
+				}
+
+				// 갱신된 토큰으로 원래 요청 재시도
+				originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+				LocalStorage.setItem('access', accessToken);
+
+				return authAxios(originalRequest); // 재시도된 요청 반환
+			} catch (refreshError) {
+				alert('토큰이 만료되었습니다. 재로그인 후 시도해주세요!');
+				LocalStorage.removeItem('access');
+				LocalStorage.removeItem('refresh');
+				window.location.href = '/login'; // 로그인 페이지로 리다이렉트
+				return Promise.reject(refreshError); // 에러 전달
+			}
+		},
+	);
+
+	return authAxios;
+};

--- a/src/apis/docs.ts
+++ b/src/apis/docs.ts
@@ -24,10 +24,6 @@ export const getSearchResult = async (keyword: string): Promise<ISearchResult | 
 export const newDocs = async (body: CreateDocs) => {
 	try {
 		const access = LocalStorage.getItem('access');
-
-		if (!access) {
-			throw new Error('Access token이 없습니다.');
-		}
 		
 		const authAxios = getAuthAxios(access);
 		const response = await authAxios.post(`${baseURL}docs/`, body);

--- a/src/apis/docs.ts
+++ b/src/apis/docs.ts
@@ -3,6 +3,7 @@ import axios, { AxiosResponse } from 'axios';
 import { Server } from './settings';
 import LocalStorage from '@/utils/localStorage';
 import { ISearchResult, ISearchResultList, SearchResult } from '@/types/search';
+import { getAuthAxios } from './authAxois';
 
 const baseURL = process.env.NEXT_PUBLIC_SERVER_URL;
 
@@ -22,15 +23,17 @@ export const getSearchResult = async (keyword: string): Promise<ISearchResult | 
 
 export const newDocs = async (body: CreateDocs) => {
 	try {
-		const token = LocalStorage.getItem('access');
-		const result = await axios.post(`${baseURL}docs/`, body, {
-			headers: {
-				Authorization: `Bearer ${token}`,
-			},
-		});
-		return result.data;
+		const access = LocalStorage.getItem('access');
+
+		if (!access) {
+			throw new Error('Access token이 없습니다.');
+		}
+		
+		const authAxios = getAuthAxios(access);
+		const response = await authAxios.post(`${baseURL}docs/`, body);
+
+		return response.data;
 	} catch (error) {
-		alert('로그아웃 후 다시 시도해주세요!');
 		throw error;
 	}
 };

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -18,71 +18,36 @@ export const postCode = async (body: postCodeBody) => {
 		}
 		return response.data;
 	} catch (error) {
-		console.error('에러 발생', error);
+		// console.error('에러 발생', error);
 		throw error;
 	}
 };
 
 // 토큰 재발급
-// export const getNewRefreshToken = async () => {
-// 	const accessToken = localStorage.getItem("access");
-// 	const refreshToken = localStorage.getItem("refresh");
-// 	const result = await axios.post(
-// 	  "http://front.cau-likelion.org/refresh",
-// 	  {
-// 		// 요청 body
-// 		refreshToken,
-// 	  },
-// 	  {
-// 		// headers.Authorization 필수
-// 		headers: {
-// 		  Authorization: accessToken,
-// 		},
-// 	  }
-// 	);
-// 	console.log(result)
-// 	return result.data;
-//   };
-
-// 회원가입
-export const signUp = async (emailInput: string, nameInput: string) => {
-	// 구글 로그인 후 context에 이메일 저장하고 있음
+export const getNewToken = async () => {
+	const refreshToken = localStorage.getItem('refresh');
 	try {
-		const response = await axios.post(`${baseURL}users/signup/`, { email: emailInput, name: nameInput });
-		if (response.data.status === '201') {
-			const accessToken = response.data.data.token.access_token;
-			const refreshToken = response.data.data.token.refresh_token;
+		const response = await axios.post(
+			`${baseURL}users/token/refresh/`,
+			{
+				refresh: refreshToken,
+			},
+			{
+				headers: {
+					Authorization: `Bearer ${refreshToken}`,
+				},
+			},
+		);
 
-			LocalStorage.setItem('access', accessToken);
-			LocalStorage.setItem('refresh', refreshToken);
+		if (response.status === 200) {
+			const newAccessToken = response.data.access;
+			return {
+				accessToken: newAccessToken,
+			};
+		} else {
+			throw new Error('토큰 갱신 실패');
 		}
-		return response.data;
 	} catch (error) {
-		console.log(error);
-		return false;
-	}
-};
-
-// 랜덤 닉네임 부여
-export const getRandomNickname = async () => {
-	try {
-		const response = await axios.get(`${baseURL}users/rand-name/`);
-		return response.data;
-	} catch (error) {
-		console.log(error);
-		return false;
-	}
-};
-
-// 닉네임 중복여부 확인
-export const checkNickName = async (name: string) => {
-	var resultString = name.replace(/\s+/g, '+');
-	try {
-		const response = await axios.get(`${baseURL}users/check-name/?name=${resultString}`);
-		return response.data;
-	} catch (error) {
-		// 사용할 수 없는 닉네임
-		console.log(error);
-		return false;
+		throw new Error('토큰 갱신 요청 실패');
 	}
 };

--- a/src/apis/signup.ts
+++ b/src/apis/signup.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import LocalStorage from '@/utils/localStorage';
+
+const baseURL = process.env.NEXT_PUBLIC_SERVER_URL;
+
+// 회원가입
+export const signUp = async (emailInput: string, nameInput: string) => {
+	// 구글 로그인 후 context에 이메일 저장하고 있음
+	try {
+		const response = await axios.post(`${baseURL}users/signup/`, { email: emailInput, name: nameInput });
+		if (response.data.status === '201') {
+			const accessToken = response.data.data.token.access_token;
+			const refreshToken = response.data.data.token.refresh_token;
+
+			LocalStorage.setItem('access', accessToken);
+			LocalStorage.setItem('refresh', refreshToken);
+		}
+		return response.data;
+	} catch (error) {
+		console.log(error);
+		return false;
+	}
+};
+
+// 랜덤 닉네임 부여
+export const getRandomNickname = async () => {
+	try {
+		const response = await axios.get(`${baseURL}users/rand-name/`);
+		return response.data;
+	} catch (error) {
+		console.log(error);
+		return false;
+	}
+};
+
+// 닉네임 중복여부 확인
+export const checkNickName = async (name: string) => {
+	let resultString = name.replace(/\s+/g, '+');
+	try {
+		const response = await axios.get(`${baseURL}users/check-name/?name=${resultString}`);
+		return response.data;
+	} catch (error) {
+		// 사용할 수 없는 닉네임
+		console.log(error);
+		return false;
+	}
+};

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -2,13 +2,12 @@
 
 import { styled } from 'styled-components';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import { token } from '@/app/recoilContextProvider';
-import { useRecoilValue } from 'recoil';
+import { usePathname, useRouter } from 'next/navigation';
 import { getRandomDoc } from '@/apis/viewer';
 import { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import SearchHeaderInput from '../search/searchHeaderInput/searchHeaderInput';
+import { AuthVerify } from '@/apis/authAxois';
 
 export interface IMenu {
 	src: string;
@@ -18,8 +17,7 @@ export interface IMenu {
 const NavBar = () => {
 	const isMobile = useMediaQuery({ query: '(max-width: 540px)' });
 	const router = useRouter();
-
-	const { access: tokenState } = useRecoilValue(token);
+	const pathname = usePathname();
 	const [isLogin, setIsLogin] = useState(false);
 
 	const gotoRandomDoc = async () => {
@@ -29,64 +27,47 @@ const NavBar = () => {
 		router.push(`/viewer?title=${encodedTitle}`);
 	};
 
+	const handlePostClick = () => {
+		if (!isLogin) {
+			alert('🦁 로그인을 먼저 해주세요 🦁');
+			router.push('/login');
+		} else {
+			router.push('/post');
+		}
+	};
+
+	// 유효한 토큰을 가진 경우에만 상태 변경
 	useEffect(() => {
-		if (tokenState) setIsLogin(true);
-	}, [tokenState]);
+		const loginStatus = AuthVerify();
+		setIsLogin(loginStatus === true);
+	}, [pathname]);
 
 	return (
 		<>
 			<Margin />
 			<Wrapper>
-				{isMobile ? (
-					<LeftWrapper>
-						<Image
-							onClick={() => {
-								router.push('/');
-							}}
-							src="/img/mobileLogo.png"
-							alt={'logo'}
-							width={100}
-							height={34}
-						/>
-					</LeftWrapper>
-				) : (
-					<LeftWrapper>
-						<Image
-							onClick={() => {
-								router.push('/');
-							}}
-							src="/img/logo.png"
-							alt={'logo'}
-							width={140}
-							height={34}
-						/>
-					</LeftWrapper>
-				)}
+				<LeftWrapper onClick={() => router.push('/')}>
+					<Image
+						src={isMobile ? '/img/mobileLogo.png' : '/img/logo.png'}
+						alt={'logo'}
+						width={isMobile ? 100 : 140}
+						height={34}
+					/>
+				</LeftWrapper>
 				<RightWrapper>
-					{isMobile ? (
-						<SearchWrapper>
-							<SearchHeaderInput />
-						</SearchWrapper>
-					) : (
-						<SearchWrapper>
-							<SearchHeaderInput />
-						</SearchWrapper>
-					)}
+					<SearchWrapper>
+						<SearchHeaderInput />
+					</SearchWrapper>
 					<ButtonWrapper>
-						{isMobile ? (
-							<div></div>
-						) : (
+						{isMobile ? null : (
 							<Image
 								onClick={() => {
 									if (!isLogin) {
-										alert('🦁 로그인을 먼저 해주세요 🦁');
 										router.push('/login');
-									} else {
-										router.push('/post');
 									}
 								}}
-								src="/img/newPost.png"
-								alt={'newPost'}
+								src={isLogin ? '/img/welcome.png' : '/img/login.png'}
+								alt={isLogin ? '로그인버튼' : '로그인'}
 								width={44}
 								height={44}
 								style={{ cursor: 'pointer' }}
@@ -100,20 +81,17 @@ const NavBar = () => {
 							height={44}
 							style={{ cursor: 'pointer' }}
 						/>
-						{isLogin ? (
-							<Image src="/img/welcome.png" width={44} height={44} alt={'로그인버튼'} />
-						) : (
+						{!isMobile && (
 							<Image
-								src="/img/login.png"
-								onClick={() => {
-									router.push(`/login`);
-								}}
+								onClick={handlePostClick}
+								src="/img/newPost.png"
+								alt={'newPost'}
 								width={44}
 								height={44}
-								alt={'로그인버튼'}
 								style={{ cursor: 'pointer' }}
 							/>
 						)}
+						{/* {isLogin && <button onClick={handleLogoutClick}>로그아웃</button>} */}
 					</ButtonWrapper>
 				</RightWrapper>
 			</Wrapper>

--- a/src/components/common/viewer/LinkBox.tsx
+++ b/src/components/common/viewer/LinkBox.tsx
@@ -1,5 +1,6 @@
+import { AuthVerify } from '@/apis/authAxois';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface LinkBoxProps {
 	width?: string;
@@ -11,16 +12,17 @@ interface LinkBoxProps {
 
 const LinkBox: React.FC<LinkBoxProps> = ({ width = '51', height = '34', text, docTitle = '' }) => {
 	const router = useRouter();
-	let token: string | null;
-	if (typeof window !== 'undefined') {
-		token = localStorage.getItem('access');
-	}
+	const [isLogin, setIsLogin] = useState(false);
+
+	useEffect(() => {
+		const loginStatus = AuthVerify();
+		setIsLogin(loginStatus === true);
+	}, []);
 
 	const handleClick = () => {
 		if (text === '편집') {
-			if (!token) {
-				alert('🦁로그인을 먼저 해주세요🦁');
-				router.push('/login');
+			if (!isLogin) {
+				alert('로그인 후 편집이 가능합니다');
 			} else {
 				let encodedTitle = encodeURIComponent(docTitle);
 				router.push(`/edit?title=${encodedTitle}`);

--- a/src/components/userName/ConfirmModal.tsx
+++ b/src/components/userName/ConfirmModal.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 import React, { useState } from 'react';
 import Image from 'next/image';
-import { signUp } from '@/apis/login';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { token, userEmailAtom, userNameAtom } from '@/app/recoilContextProvider';
 import { useRouter } from 'next/navigation';
 import LocalStorage from '@/utils/localStorage';
+import { signUp } from '@/apis/signup';
 
 const ConfirmModal = (props: { setModalIsOpen: React.Dispatch<React.SetStateAction<boolean>>; nickname: string }) => {
 	const route = useRouter();

--- a/src/components/userName/UserNickNameMain.tsx
+++ b/src/components/userName/UserNickNameMain.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import ConfirmModal from './ConfirmModal';
-import { checkNickName, getRandomNickname } from '@/apis/login';
+import { checkNickName, getRandomNickname } from '@/apis/signup';
 
 const UserNickNameMain = () => {
 	const [userNickname, setUserNickname] = useState('어쩔사자티비');

--- a/src/utils/historyUtils.ts
+++ b/src/utils/historyUtils.ts
@@ -1,66 +1,74 @@
-export const renderOldStr = (change: any) => {
-    var oldStr = change.replace(
-        /<modified_to>(.*?)<\/modified_to>|<added>(.*?)<\/added>/g,
-        function ([match, p1, p2]: any) {
-            return p1 ? ' ' : p2 ? ' ' : '';
-        },
-    );
-
-    oldStr = oldStr.replace(/<added>/g, ' ' + "<span class='none'>");
-    oldStr = oldStr.replace(/<\/added>/g, '</span>');
-    oldStr = oldStr.replace(/<modified_to>/g, ' ' + "<span class='none'>");
-    oldStr = oldStr.replace(/<\/modified_to>/g, '</span>');
-
-    oldStr = oldStr.replace(/<deleted>/g, ' ' + "<span class='delete'>");
-    oldStr = oldStr.replace(/<\/deleted>/g, '</span>');
-    oldStr = oldStr.replace(/<modified_from>/g, ' ' + "<span class='from'>");
-    oldStr = oldStr.replace(/<\/modified_from>/g, '</span>');
-
-    oldStr = oldStr.replace(/\r\n|\n|\r|\\r\\n|\\n|\\r/g, '<br/>');
-
-    return { __html: oldStr };
+export const cleanImageTag = (str: string): string => {
+	return str
+		.replace(/<img\s+([^>]*?)\s*>/g, (match: string, p1: string) => {
+			p1 = p1.replace(/(src\s*=\s*["'])(.*?)(["'])/g, (match: string, prefix: string, url: string, suffix: string) => {
+				return prefix + url.replace(/\s+/g, '') + suffix;
+			});
+			return `<img ${p1.replace(/\s*=\s*/g, '=').replace(/\s+/g, ' ')}>`;
+		})
+		.replace(/"\s/g, '"')
+		.replace(/\s"/g, '"')
+		.trim();
 };
 
-export const renderNewStr = (change: any) => {
-    let newStr = change.replace(
-        /<modified_from>(.*?)<\/modified_from>|<deleted>(.*?)<\/deleted>/g,
-        function (): string {
-            return '';
-        },
-    );
+export const renderOldStr = (change: string): { __html: string } => {
+	let oldStr = change.replace(/<modified_to>(.*?)<\/modified_to>|<added>(.*?)<\/added>/g, (match, p1, p2) =>
+		p1 ? ' ' : p2 ? ' ' : '',
+	);
 
-    newStr = newStr.replace(/<deleted>/g, ' ' + "<span class='none'>");
-    newStr = newStr.replace(/<\/deleted>/g, '</span>');
-    newStr = newStr.replace(/<modified_from>/g, ' ' + "<span class='none'>");
-    newStr = newStr.replace(/<\/modified_from>/g, '</span>');
+	oldStr = oldStr
+		.replace(/<added>/g, " <span class='none'>")
+		.replace(/<\/added>/g, '</span>')
+		.replace(/<modified_to>/g, " <span class='none'>")
+		.replace(/<\/modified_to>/g, '</span>')
+		.replace(/<deleted>/g, " <span class='delete'>")
+		.replace(/<\/deleted>/g, '</span>')
+		.replace(/<modified_from>/g, " <span class='from'>")
+		.replace(/<\/modified_from>/g, '</span>')
+		.replace(/\r\n|\n|\r|\\r\\n|\\n|\\r/g, '<br/>');
 
-    newStr = newStr.replace(/<added>/g, ' ' + "<span class='add'>");
-    newStr = newStr.replace(/<\/added>/g, '</span>');
-    newStr = newStr.replace(/<modified_to>/g, ' ' + "<span class='to'>");
-    newStr = newStr.replace(/<\/modified_to>/g, '</span>');
+	oldStr = cleanImageTag(oldStr);
 
-    newStr = newStr.replace(/\r\n|\n|\r|\\r\\n|\\n|\\r/g, '<br/>');
-
-    return { __html: newStr };
-};
-export const renderFirstStr = (content: any) => {
-    let firstStr = content;
-
-    firstStr = firstStr.replace(/\r\n|\n|\r|\\r\\n|\\n|\\r/g, '<br/>');
-    firstStr = "<span class='add'>" + firstStr + '</span>';
-
-    return { __html: firstStr };
+	return { __html: oldStr };
 };
 
-export const parseAndFormatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    const options: Intl.DateTimeFormatOptions = {
-        year: 'numeric',
-        month: 'numeric',
-        day: 'numeric',
-        weekday: 'short',
-        hour: 'numeric',
-        minute: 'numeric',
-    };
-    return date.toLocaleString('ko-KR', options);
+export const renderNewStr = (change: string): { __html: string } => {
+	let newStr = change.replace(/<modified_from>(.*?)<\/modified_from>|<deleted>(.*?)<\/deleted>/g, () => '');
+
+	newStr = newStr
+		.replace(/<deleted>/g, " <span class='none'>")
+		.replace(/<\/deleted>/g, '</span>')
+		.replace(/<modified_from>/g, " <span class='none'>")
+		.replace(/<\/modified_from>/g, '</span>')
+		.replace(/<added>/g, " <span class='add'>")
+		.replace(/<\/added>/g, '</span>')
+		.replace(/<modified_to>/g, " <span class='to'>")
+		.replace(/<\/modified_to>/g, '</span>')
+		.replace(/\r\n|\n|\r|\\r\\n|\\n|\\r/g, '<br/>');
+
+	newStr = cleanImageTag(newStr);
+
+	return { __html: newStr };
+};
+
+export const renderFirstStr = (content: string): { __html: string } => {
+	let firstStr = content.replace(/\r\n|\n|\r|\\r\\n|\\n|\\r/g, '<br/>');
+	firstStr = `<span class='add'>${firstStr}</span>`;
+
+	firstStr = cleanImageTag(firstStr);
+
+	return { __html: firstStr };
+};
+
+export const parseAndFormatDate = (dateString: string): string => {
+	const date = new Date(dateString);
+	const options: Intl.DateTimeFormatOptions = {
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric',
+		weekday: 'short',
+		hour: 'numeric',
+		minute: 'numeric',
+	};
+	return date.toLocaleString('ko-KR', options);
 };


### PR DESCRIPTION
## 📌 PR 내용
***
- refresh token을 통한 access token 재발급
- axios interceptors로 토큰 자동연장 구현
- 현재 로컬스토리지에 저장되어 있는 토큰의 유효성을 판단하는 AuthVerify 메서드 구현
- 네브바, 문서 생성, 편집 등 기존 access 토큰 유무로 로그인 여부 판단하던 코드를, AuthVerify를 이용해 개선
- 향후 로그아웃 버튼도 추가 예정

## 📝 코드 요약
***
-'''login'''
-'''authAxios'''

## 💌 해결 이슈
***
- Resolved : #119 

## 📸 스크린샷 (선택)
***