### PR TITLE
[FEAT] 만료기간 검사 과정에서 로그인 자동 연장 및 자동 로그아웃 구현

### DIFF
--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -38,8 +38,12 @@ const NavBar = () => {
 
 	// 유효한 토큰을 가진 경우에만 상태 변경
 	useEffect(() => {
-		const loginStatus = AuthVerify();
-		setIsLogin(loginStatus === true);
+		const checkLoginStatus = async () => {
+			const loginStatus = await AuthVerify();
+			setIsLogin(loginStatus === true);
+		};
+
+		checkLoginStatus();
 	}, [pathname]);
 
 	return (

--- a/src/components/common/viewer/LinkBox.tsx
+++ b/src/components/common/viewer/LinkBox.tsx
@@ -15,8 +15,12 @@ const LinkBox: React.FC<LinkBoxProps> = ({ width = '51', height = '34', text, do
 	const [isLogin, setIsLogin] = useState(false);
 
 	useEffect(() => {
-		const loginStatus = AuthVerify();
-		setIsLogin(loginStatus === true);
+		const checkLoginStatus = async () => {
+			const loginStatus = await AuthVerify();
+			setIsLogin(loginStatus === true);
+		};
+
+		checkLoginStatus();
 	}, []);
 
 	const handleClick = () => {


### PR DESCRIPTION
## 📌 PR 내용
***
- 기존 코드의 경우 문서 편집 과정에서만 재발급이 이뤄지도록 하고, 요청이 없을시에는 access가 만료되어도 재발급 대신 로그아웃이 이뤄지도록 했던 부분을 추가 개선했습니다.
- 네브바에서 사용자 토큰의 유효성을 검사하며 자동으로 토큰 재발급 및 로그아웃이 이뤄지도록 수정했습니다
- access, refresh 토큰 중 무엇 하나라도 미존재 할 시 -> 미로그인 상태
- access, refresh 모두 만료인 상태 -> alert로 토큰 만료를 알리고 자동 로그아웃
- access만 만료인 상태 -> 로그인 자동 재연장

## 📝 코드 요약
***
-'''authAxois'''

## 💌 해결 이슈
***
- Resolved : #119 

## 📸 스크린샷 (선택)
***